### PR TITLE
[22.11.13] Update : coin 리셋 제거 & 캐릭터 처음좌표로 이동

### DIFF
--- a/Platformer-master/db/db_interface.py
+++ b/Platformer-master/db/db_interface.py
@@ -1,0 +1,39 @@
+import sqlite3
+
+
+class InterfDB:
+
+    def __init__(self, dbname):
+        self.__DBNAME = "test.db"
+        self.db = sqlite3.connect(self.__DBNAME)
+
+    def init_db(self):
+        with open("./db/schema.sql", 'r') as f:
+            self.db.cursor().executescript(f.read())
+        self.db.commit()
+
+    def query_db(self, query, args=(), one=False):
+        cursor = self.db.execute(query, args)
+        result = [dict((cursor.description[idx][0], value) for idx, value in enumerate(row)) \
+                  for row in cursor.fetchall()]
+        #fetchall() 모든 데이터 한 번에 가져올 때 사용
+        return (result[0] if result else None) if one else result
+
+    def commit(self):
+        self.db.commit()
+
+    def is_limit_data(self, score, limit=10, mode=""):
+        num_of_data = self.query_db(f"select count(score) from {mode}_mode;")[0]['count(score)']
+        try:
+            last_data = self.query_db("select score from user order by score asc;", one=True)['score']
+        except:
+            return False
+        if num_of_data == limit:
+            if score > last_data:
+                self.query_db(f"delete from user where score={last_data};")
+                self.commit()
+                return False
+            else:
+                return True
+        else:
+            return False

--- a/Platformer-master/main.py
+++ b/Platformer-master/main.py
@@ -25,10 +25,10 @@ font_score = pygame.font.SysFont('Bauhaus 93', 30)
 
 #define game variables
 tile_size = 50
-game_over = 0
-main_menu = True
+game_over = 0  # game over 일때를 0으로 설정
+main_menu = True  
 level = 3
-max_levels = 7
+max_levels = 7 
 score = 0
 
 
@@ -57,8 +57,8 @@ game_over_fx.set_volume(0.5)
 
 
 def draw_text(text, font, text_col, x, y):
-	img = font.render(text, True, text_col)
-	screen.blit(img, (x, y))
+	img = font.render(text, True, text_col)  
+	screen.blit(img, (x, y))  # screen.blit(이미지, 대상) -> 이미지 복사
 
 
 #function to reset level
@@ -224,12 +224,16 @@ class Player():
 			self.rect.x += dx
 			self.rect.y += dy
 
-
-		elif game_over == -1:
+        
+		elif game_over == -1:   
 			self.image = self.dead_image
 			draw_text('GAME OVER!', font, blue, (screen_width // 2) - 200, screen_height // 2)
-			if self.rect.y > 200:
-				self.rect.y -= 5
+			if self.rect.y > 200:   # 죽으면 유령으로 바뀌고 설정한 범위만큼 위로 올라감
+				self.rect.y -= 5   
+            
+
+            
+            
 
 		#draw player onto screen
 		screen.blit(self.image, self.rect)
@@ -424,9 +428,9 @@ while run:
 	screen.blit(sun_img, (100, 100))
 
 	if main_menu == True:
-		if exit_button.draw():
-			run = False
-		if start_button.draw():
+		if exit_button.draw(): # exit 버튼 누르면 while 반복 루프에서 벗어남
+			run = False     
+		if start_button.draw(): # start 버튼 누르면 
 			main_menu = False
 	else:
 		world.draw()
@@ -451,11 +455,10 @@ while run:
 
 		#if player has died
 		if game_over == -1:
-			if restart_button.draw():
 				world_data = []
 				world = reset_level(level)
 				game_over = 0
-				score = 0
+				# score = 0   # 획득한 코인 리셋 안되게 이코드 주석
 
 		#if player has completed the level
 		if game_over == 1:

--- a/Platformer-master/main.py
+++ b/Platformer-master/main.py
@@ -27,7 +27,7 @@ font_score = pygame.font.SysFont('Bauhaus 93', 30)
 tile_size = 50
 game_over = 0  # game over 일때를 0으로 설정
 main_menu = True  
-level = 3
+level = 1
 max_levels = 7 
 score = 0
 


### PR DESCRIPTION
기존 코드에서 캐릭터가 용암과 장애물에 닿였을때 코인 스코어가 초기와 되고 restart 버튼이 생성 되었음 
변경된 코드에서 캐릭터가 용암과 장애물에 닿여도 코인이 초기화 안되고 restart 버튼 생성없이 맵의 초기 좌표로 이동하도록 코드 업데이트 시킴